### PR TITLE
Stage 3/presentation blocs

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -38,8 +38,6 @@ Future<void> initializeDependencies() async {
   );
 
   getIt.registerFactory<SettingsBloc>(
-    () => SettingsBloc(
-      settingsRepository: getIt(),
-    ),
+    () => SettingsBloc(settingsRepository: getIt()),
   );
 }

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -6,6 +6,8 @@ import '../../data/repositories/settings_repository_impl.dart';
 import '../../domain/repositories/settings_repository.dart';
 import '../../domain/usecases/calculate_gate_output.dart';
 import '../../domain/usecases/get_truth_table.dart';
+import '../../presentation/blocs/gate_simulator/gate_simulator_bloc.dart';
+import '../../presentation/blocs/settings/settings_bloc.dart';
 
 final getIt = GetIt.instance;
 
@@ -26,4 +28,18 @@ Future<void> initializeDependencies() async {
   getIt.registerSingleton<CalculateGateOutput>(CalculateGateOutput());
 
   getIt.registerSingleton<GetTruthTable>(GetTruthTable(getIt()));
+
+  // BLoCs
+  getIt.registerFactory<GateSimulatorBloc>(
+    () => GateSimulatorBloc(
+      calculateGateOutput: getIt(),
+      settingsRepository: getIt(),
+    ),
+  );
+
+  getIt.registerFactory<SettingsBloc>(
+    () => SettingsBloc(
+      settingsRepository: getIt(),
+    ),
+  );
 }

--- a/lib/domain/entities/gate_result.dart
+++ b/lib/domain/entities/gate_result.dart
@@ -4,7 +4,7 @@ part 'gate_result.freezed.dart';
 
 /// Represents the result of a gate calculation with input values
 @freezed
-class GateResult with _$GateResult {
+abstract class GateResult with _$GateResult {
   const factory GateResult({
     required bool output,
     required bool inputA,

--- a/lib/domain/entities/gate_result.freezed.dart
+++ b/lib/domain/entities/gate_result.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,184 +9,269 @@ part of 'gate_result.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
 /// @nodoc
 mixin _$GateResult {
-  bool get output => throw _privateConstructorUsedError;
-  bool get inputA => throw _privateConstructorUsedError;
-  bool get inputB => throw _privateConstructorUsedError;
 
-  /// Create a copy of GateResult
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $GateResultCopyWith<GateResult> get copyWith =>
-      throw _privateConstructorUsedError;
+ bool get output; bool get inputA; bool get inputB;
+/// Create a copy of GateResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GateResultCopyWith<GateResult> get copyWith => _$GateResultCopyWithImpl<GateResult>(this as GateResult, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GateResult&&(identical(other.output, output) || other.output == output)&&(identical(other.inputA, inputA) || other.inputA == inputA)&&(identical(other.inputB, inputB) || other.inputB == inputB));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,output,inputA,inputB);
+
+@override
+String toString() {
+  return 'GateResult(output: $output, inputA: $inputA, inputB: $inputB)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $GateResultCopyWith<$Res> {
-  factory $GateResultCopyWith(
-    GateResult value,
-    $Res Function(GateResult) then,
-  ) = _$GateResultCopyWithImpl<$Res, GateResult>;
-  @useResult
-  $Res call({bool output, bool inputA, bool inputB});
-}
+abstract mixin class $GateResultCopyWith<$Res>  {
+  factory $GateResultCopyWith(GateResult value, $Res Function(GateResult) _then) = _$GateResultCopyWithImpl;
+@useResult
+$Res call({
+ bool output, bool inputA, bool inputB
+});
 
+
+
+
+}
 /// @nodoc
-class _$GateResultCopyWithImpl<$Res, $Val extends GateResult>
+class _$GateResultCopyWithImpl<$Res>
     implements $GateResultCopyWith<$Res> {
-  _$GateResultCopyWithImpl(this._value, this._then);
+  _$GateResultCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final GateResult _self;
+  final $Res Function(GateResult) _then;
 
-  /// Create a copy of GateResult
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? output = null,
-    Object? inputA = null,
-    Object? inputB = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            output: null == output
-                ? _value.output
-                : output // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            inputA: null == inputA
-                ? _value.inputA
-                : inputA // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            inputB: null == inputB
-                ? _value.inputB
-                : inputB // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
-  }
+/// Create a copy of GateResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? output = null,Object? inputA = null,Object? inputB = null,}) {
+  return _then(_self.copyWith(
+output: null == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
+as bool,inputA: null == inputA ? _self.inputA : inputA // ignore: cast_nullable_to_non_nullable
+as bool,inputB: null == inputB ? _self.inputB : inputB // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GateResult].
+extension GateResultPatterns on GateResult {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GateResult value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GateResult() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GateResult value)  $default,){
+final _that = this;
+switch (_that) {
+case _GateResult():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GateResult value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GateResult() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool output,  bool inputA,  bool inputB)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GateResult() when $default != null:
+return $default(_that.output,_that.inputA,_that.inputB);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool output,  bool inputA,  bool inputB)  $default,) {final _that = this;
+switch (_that) {
+case _GateResult():
+return $default(_that.output,_that.inputA,_that.inputB);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool output,  bool inputA,  bool inputB)?  $default,) {final _that = this;
+switch (_that) {
+case _GateResult() when $default != null:
+return $default(_that.output,_that.inputA,_that.inputB);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$GateResultImplCopyWith<$Res>
-    implements $GateResultCopyWith<$Res> {
-  factory _$$GateResultImplCopyWith(
-    _$GateResultImpl value,
-    $Res Function(_$GateResultImpl) then,
-  ) = __$$GateResultImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({bool output, bool inputA, bool inputB});
+
+
+class _GateResult implements GateResult {
+  const _GateResult({required this.output, required this.inputA, required this.inputB});
+  
+
+@override final  bool output;
+@override final  bool inputA;
+@override final  bool inputB;
+
+/// Create a copy of GateResult
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GateResultCopyWith<_GateResult> get copyWith => __$GateResultCopyWithImpl<_GateResult>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GateResult&&(identical(other.output, output) || other.output == output)&&(identical(other.inputA, inputA) || other.inputA == inputA)&&(identical(other.inputB, inputB) || other.inputB == inputB));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,output,inputA,inputB);
+
+@override
+String toString() {
+  return 'GateResult(output: $output, inputA: $inputA, inputB: $inputB)';
+}
+
+
 }
 
 /// @nodoc
-class __$$GateResultImplCopyWithImpl<$Res>
-    extends _$GateResultCopyWithImpl<$Res, _$GateResultImpl>
-    implements _$$GateResultImplCopyWith<$Res> {
-  __$$GateResultImplCopyWithImpl(
-    _$GateResultImpl _value,
-    $Res Function(_$GateResultImpl) _then,
-  ) : super(_value, _then);
+abstract mixin class _$GateResultCopyWith<$Res> implements $GateResultCopyWith<$Res> {
+  factory _$GateResultCopyWith(_GateResult value, $Res Function(_GateResult) _then) = __$GateResultCopyWithImpl;
+@override @useResult
+$Res call({
+ bool output, bool inputA, bool inputB
+});
 
-  /// Create a copy of GateResult
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? output = null,
-    Object? inputA = null,
-    Object? inputB = null,
-  }) {
-    return _then(
-      _$GateResultImpl(
-        output: null == output
-            ? _value.output
-            : output // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        inputA: null == inputA
-            ? _value.inputA
-            : inputA // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        inputB: null == inputB
-            ? _value.inputB
-            : inputB // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
-  }
+
+
+
 }
-
 /// @nodoc
+class __$GateResultCopyWithImpl<$Res>
+    implements _$GateResultCopyWith<$Res> {
+  __$GateResultCopyWithImpl(this._self, this._then);
 
-class _$GateResultImpl implements _GateResult {
-  const _$GateResultImpl({
-    required this.output,
-    required this.inputA,
-    required this.inputB,
-  });
+  final _GateResult _self;
+  final $Res Function(_GateResult) _then;
 
-  @override
-  final bool output;
-  @override
-  final bool inputA;
-  @override
-  final bool inputB;
-
-  @override
-  String toString() {
-    return 'GateResult(output: $output, inputA: $inputA, inputB: $inputB)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$GateResultImpl &&
-            (identical(other.output, output) || other.output == output) &&
-            (identical(other.inputA, inputA) || other.inputA == inputA) &&
-            (identical(other.inputB, inputB) || other.inputB == inputB));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, output, inputA, inputB);
-
-  /// Create a copy of GateResult
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$GateResultImplCopyWith<_$GateResultImpl> get copyWith =>
-      __$$GateResultImplCopyWithImpl<_$GateResultImpl>(this, _$identity);
+/// Create a copy of GateResult
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? output = null,Object? inputA = null,Object? inputB = null,}) {
+  return _then(_GateResult(
+output: null == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
+as bool,inputA: null == inputA ? _self.inputA : inputA // ignore: cast_nullable_to_non_nullable
+as bool,inputB: null == inputB ? _self.inputB : inputB // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-abstract class _GateResult implements GateResult {
-  const factory _GateResult({
-    required final bool output,
-    required final bool inputA,
-    required final bool inputB,
-  }) = _$GateResultImpl;
 
-  @override
-  bool get output;
-  @override
-  bool get inputA;
-  @override
-  bool get inputB;
-
-  /// Create a copy of GateResult
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GateResultImplCopyWith<_$GateResultImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
+
+// dart format on

--- a/lib/domain/entities/logic_gate.dart
+++ b/lib/domain/entities/logic_gate.dart
@@ -1,15 +1,21 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'gate_type.dart';
+import '../../core/constants/gate_constants.dart';
 
 part 'logic_gate.freezed.dart';
 
 /// Represents a logic gate with its properties
 @freezed
-class LogicGate with _$LogicGate {
+abstract class LogicGate with _$LogicGate {
   const factory LogicGate({
     required GateType type,
     required String name,
     required String formula,
     required String description,
   }) = _LogicGate;
+
+  /// Create a LogicGate from a GateType
+  factory LogicGate.fromType(GateType type) {
+    return GateConstants.getGate(type);
+  }
 }

--- a/lib/domain/entities/logic_gate.freezed.dart
+++ b/lib/domain/entities/logic_gate.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,202 +9,272 @@ part of 'logic_gate.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
 /// @nodoc
 mixin _$LogicGate {
-  GateType get type => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  String get formula => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
 
-  /// Create a copy of LogicGate
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $LogicGateCopyWith<LogicGate> get copyWith =>
-      throw _privateConstructorUsedError;
+ GateType get type; String get name; String get formula; String get description;
+/// Create a copy of LogicGate
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LogicGateCopyWith<LogicGate> get copyWith => _$LogicGateCopyWithImpl<LogicGate>(this as LogicGate, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LogicGate&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.formula, formula) || other.formula == formula)&&(identical(other.description, description) || other.description == description));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,type,name,formula,description);
+
+@override
+String toString() {
+  return 'LogicGate(type: $type, name: $name, formula: $formula, description: $description)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $LogicGateCopyWith<$Res> {
-  factory $LogicGateCopyWith(LogicGate value, $Res Function(LogicGate) then) =
-      _$LogicGateCopyWithImpl<$Res, LogicGate>;
-  @useResult
-  $Res call({GateType type, String name, String formula, String description});
-}
+abstract mixin class $LogicGateCopyWith<$Res>  {
+  factory $LogicGateCopyWith(LogicGate value, $Res Function(LogicGate) _then) = _$LogicGateCopyWithImpl;
+@useResult
+$Res call({
+ GateType type, String name, String formula, String description
+});
 
+
+
+
+}
 /// @nodoc
-class _$LogicGateCopyWithImpl<$Res, $Val extends LogicGate>
+class _$LogicGateCopyWithImpl<$Res>
     implements $LogicGateCopyWith<$Res> {
-  _$LogicGateCopyWithImpl(this._value, this._then);
+  _$LogicGateCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final LogicGate _self;
+  final $Res Function(LogicGate) _then;
 
-  /// Create a copy of LogicGate
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? type = null,
-    Object? name = null,
-    Object? formula = null,
-    Object? description = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            type: null == type
-                ? _value.type
-                : type // ignore: cast_nullable_to_non_nullable
-                      as GateType,
-            name: null == name
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                      as String,
-            formula: null == formula
-                ? _value.formula
-                : formula // ignore: cast_nullable_to_non_nullable
-                      as String,
-            description: null == description
-                ? _value.description
-                : description // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
+/// Create a copy of LogicGate
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? name = null,Object? formula = null,Object? description = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as GateType,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,formula: null == formula ? _self.formula : formula // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [LogicGate].
+extension LogicGatePatterns on LogicGate {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LogicGate value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LogicGate() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LogicGate value)  $default,){
+final _that = this;
+switch (_that) {
+case _LogicGate():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LogicGate value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LogicGate() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GateType type,  String name,  String formula,  String description)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LogicGate() when $default != null:
+return $default(_that.type,_that.name,_that.formula,_that.description);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GateType type,  String name,  String formula,  String description)  $default,) {final _that = this;
+switch (_that) {
+case _LogicGate():
+return $default(_that.type,_that.name,_that.formula,_that.description);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GateType type,  String name,  String formula,  String description)?  $default,) {final _that = this;
+switch (_that) {
+case _LogicGate() when $default != null:
+return $default(_that.type,_that.name,_that.formula,_that.description);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$LogicGateImplCopyWith<$Res>
-    implements $LogicGateCopyWith<$Res> {
-  factory _$$LogicGateImplCopyWith(
-    _$LogicGateImpl value,
-    $Res Function(_$LogicGateImpl) then,
-  ) = __$$LogicGateImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({GateType type, String name, String formula, String description});
+
+
+class _LogicGate implements LogicGate {
+  const _LogicGate({required this.type, required this.name, required this.formula, required this.description});
+  
+
+@override final  GateType type;
+@override final  String name;
+@override final  String formula;
+@override final  String description;
+
+/// Create a copy of LogicGate
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LogicGateCopyWith<_LogicGate> get copyWith => __$LogicGateCopyWithImpl<_LogicGate>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LogicGate&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.formula, formula) || other.formula == formula)&&(identical(other.description, description) || other.description == description));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,type,name,formula,description);
+
+@override
+String toString() {
+  return 'LogicGate(type: $type, name: $name, formula: $formula, description: $description)';
+}
+
+
 }
 
 /// @nodoc
-class __$$LogicGateImplCopyWithImpl<$Res>
-    extends _$LogicGateCopyWithImpl<$Res, _$LogicGateImpl>
-    implements _$$LogicGateImplCopyWith<$Res> {
-  __$$LogicGateImplCopyWithImpl(
-    _$LogicGateImpl _value,
-    $Res Function(_$LogicGateImpl) _then,
-  ) : super(_value, _then);
+abstract mixin class _$LogicGateCopyWith<$Res> implements $LogicGateCopyWith<$Res> {
+  factory _$LogicGateCopyWith(_LogicGate value, $Res Function(_LogicGate) _then) = __$LogicGateCopyWithImpl;
+@override @useResult
+$Res call({
+ GateType type, String name, String formula, String description
+});
 
-  /// Create a copy of LogicGate
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? type = null,
-    Object? name = null,
-    Object? formula = null,
-    Object? description = null,
-  }) {
-    return _then(
-      _$LogicGateImpl(
-        type: null == type
-            ? _value.type
-            : type // ignore: cast_nullable_to_non_nullable
-                  as GateType,
-        name: null == name
-            ? _value.name
-            : name // ignore: cast_nullable_to_non_nullable
-                  as String,
-        formula: null == formula
-            ? _value.formula
-            : formula // ignore: cast_nullable_to_non_nullable
-                  as String,
-        description: null == description
-            ? _value.description
-            : description // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
+
+
+
 }
-
 /// @nodoc
+class __$LogicGateCopyWithImpl<$Res>
+    implements _$LogicGateCopyWith<$Res> {
+  __$LogicGateCopyWithImpl(this._self, this._then);
 
-class _$LogicGateImpl implements _LogicGate {
-  const _$LogicGateImpl({
-    required this.type,
-    required this.name,
-    required this.formula,
-    required this.description,
-  });
+  final _LogicGate _self;
+  final $Res Function(_LogicGate) _then;
 
-  @override
-  final GateType type;
-  @override
-  final String name;
-  @override
-  final String formula;
-  @override
-  final String description;
-
-  @override
-  String toString() {
-    return 'LogicGate(type: $type, name: $name, formula: $formula, description: $description)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$LogicGateImpl &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.formula, formula) || other.formula == formula) &&
-            (identical(other.description, description) ||
-                other.description == description));
-  }
-
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, type, name, formula, description);
-
-  /// Create a copy of LogicGate
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$LogicGateImplCopyWith<_$LogicGateImpl> get copyWith =>
-      __$$LogicGateImplCopyWithImpl<_$LogicGateImpl>(this, _$identity);
+/// Create a copy of LogicGate
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? name = null,Object? formula = null,Object? description = null,}) {
+  return _then(_LogicGate(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as GateType,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,formula: null == formula ? _self.formula : formula // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-abstract class _LogicGate implements LogicGate {
-  const factory _LogicGate({
-    required final GateType type,
-    required final String name,
-    required final String formula,
-    required final String description,
-  }) = _$LogicGateImpl;
 
-  @override
-  GateType get type;
-  @override
-  String get name;
-  @override
-  String get formula;
-  @override
-  String get description;
-
-  /// Create a copy of LogicGate
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$LogicGateImplCopyWith<_$LogicGateImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
+
+// dart format on

--- a/lib/presentation/blocs/gate_simulator/gate_simulator_bloc.dart
+++ b/lib/presentation/blocs/gate_simulator/gate_simulator_bloc.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../domain/entities/logic_gate.dart';
+import '../../../domain/repositories/settings_repository.dart';
+import '../../../domain/usecases/calculate_gate_output.dart';
+import 'gate_simulator_event.dart';
+import 'gate_simulator_state.dart';
+
+class GateSimulatorBloc extends Bloc<GateSimulatorEvent, GateSimulatorState> {
+  final CalculateGateOutput _calculateGateOutput;
+  final SettingsRepository _settingsRepository;
+
+  GateSimulatorBloc({
+    required CalculateGateOutput calculateGateOutput,
+    required SettingsRepository settingsRepository,
+  }) : _calculateGateOutput = calculateGateOutput,
+       _settingsRepository = settingsRepository,
+       super(GateSimulatorState.initial()) {
+    on<SelectGateType>(_onSelectGateType);
+    on<ToggleInputA>(_onToggleInputA);
+    on<ToggleInputB>(_onToggleInputB);
+    on<SetInputA>(_onSetInputA);
+    on<SetInputB>(_onSetInputB);
+    on<LoadLastGateType>(_onLoadLastGateType);
+  }
+
+  Future<void> _onSelectGateType(
+    SelectGateType event,
+    Emitter<GateSimulatorState> emit,
+  ) async {
+    final newGate = LogicGate.fromType(event.gateType);
+    final output = _calculateGateOutput(
+      event.gateType,
+      state.inputA,
+      state.inputB,
+    );
+
+    emit(
+      state.copyWith(
+        currentGateType: event.gateType,
+        currentGate: newGate,
+        output: output,
+      ),
+    );
+
+    // Save the selected gate type
+    await _settingsRepository.saveLastGateType(event.gateType);
+  }
+
+  void _onToggleInputA(ToggleInputA event, Emitter<GateSimulatorState> emit) {
+    final newInputA = !state.inputA;
+    final output = _calculateGateOutput(
+      state.currentGateType,
+      newInputA,
+      state.inputB,
+    );
+
+    emit(state.copyWith(inputA: newInputA, output: output));
+  }
+
+  void _onToggleInputB(ToggleInputB event, Emitter<GateSimulatorState> emit) {
+    final newInputB = !state.inputB;
+    final output = _calculateGateOutput(
+      state.currentGateType,
+      state.inputA,
+      newInputB,
+    );
+
+    emit(state.copyWith(inputB: newInputB, output: output));
+  }
+
+  void _onSetInputA(SetInputA event, Emitter<GateSimulatorState> emit) {
+    final output = _calculateGateOutput(
+      state.currentGateType,
+      event.value,
+      state.inputB,
+    );
+
+    emit(state.copyWith(inputA: event.value, output: output));
+  }
+
+  void _onSetInputB(SetInputB event, Emitter<GateSimulatorState> emit) {
+    final output = _calculateGateOutput(
+      state.currentGateType,
+      state.inputA,
+      event.value,
+    );
+
+    emit(state.copyWith(inputB: event.value, output: output));
+  }
+
+  Future<void> _onLoadLastGateType(
+    LoadLastGateType event,
+    Emitter<GateSimulatorState> emit,
+  ) async {
+    final lastGateType = await _settingsRepository.getLastGateType();
+    if (lastGateType != null) {
+      final newGate = LogicGate.fromType(lastGateType);
+      final output = _calculateGateOutput(
+        lastGateType,
+        state.inputA,
+        state.inputB,
+      );
+
+      emit(
+        state.copyWith(
+          currentGateType: lastGateType,
+          currentGate: newGate,
+          output: output,
+        ),
+      );
+    }
+  }
+}

--- a/lib/presentation/blocs/gate_simulator/gate_simulator_event.dart
+++ b/lib/presentation/blocs/gate_simulator/gate_simulator_event.dart
@@ -1,0 +1,49 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../domain/entities/gate_type.dart';
+
+abstract class GateSimulatorEvent extends Equatable {
+  const GateSimulatorEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class SelectGateType extends GateSimulatorEvent {
+  final GateType gateType;
+
+  const SelectGateType(this.gateType);
+
+  @override
+  List<Object?> get props => [gateType];
+}
+
+class ToggleInputA extends GateSimulatorEvent {
+  const ToggleInputA();
+}
+
+class ToggleInputB extends GateSimulatorEvent {
+  const ToggleInputB();
+}
+
+class SetInputA extends GateSimulatorEvent {
+  final bool value;
+
+  const SetInputA(this.value);
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class SetInputB extends GateSimulatorEvent {
+  final bool value;
+
+  const SetInputB(this.value);
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class LoadLastGateType extends GateSimulatorEvent {
+  const LoadLastGateType();
+}

--- a/lib/presentation/blocs/gate_simulator/gate_simulator_state.dart
+++ b/lib/presentation/blocs/gate_simulator/gate_simulator_state.dart
@@ -46,10 +46,10 @@ class GateSimulatorState extends Equatable {
 
   @override
   List<Object?> get props => [
-        currentGateType,
-        currentGate,
-        inputA,
-        inputB,
-        output,
-      ];
+    currentGateType,
+    currentGate,
+    inputA,
+    inputB,
+    output,
+  ];
 }

--- a/lib/presentation/blocs/gate_simulator/gate_simulator_state.dart
+++ b/lib/presentation/blocs/gate_simulator/gate_simulator_state.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../domain/entities/gate_type.dart';
+import '../../../domain/entities/logic_gate.dart';
+
+class GateSimulatorState extends Equatable {
+  final GateType currentGateType;
+  final LogicGate currentGate;
+  final bool inputA;
+  final bool inputB;
+  final bool output;
+
+  const GateSimulatorState({
+    required this.currentGateType,
+    required this.currentGate,
+    required this.inputA,
+    required this.inputB,
+    required this.output,
+  });
+
+  factory GateSimulatorState.initial() {
+    return GateSimulatorState(
+      currentGateType: GateType.and,
+      currentGate: LogicGate.fromType(GateType.and),
+      inputA: false,
+      inputB: false,
+      output: false,
+    );
+  }
+
+  GateSimulatorState copyWith({
+    GateType? currentGateType,
+    LogicGate? currentGate,
+    bool? inputA,
+    bool? inputB,
+    bool? output,
+  }) {
+    return GateSimulatorState(
+      currentGateType: currentGateType ?? this.currentGateType,
+      currentGate: currentGate ?? this.currentGate,
+      inputA: inputA ?? this.inputA,
+      inputB: inputB ?? this.inputB,
+      output: output ?? this.output,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        currentGateType,
+        currentGate,
+        inputA,
+        inputB,
+        output,
+      ];
+}

--- a/lib/presentation/blocs/settings/settings_bloc.dart
+++ b/lib/presentation/blocs/settings/settings_bloc.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../domain/repositories/settings_repository.dart';
+import 'settings_event.dart';
+import 'settings_state.dart';
+
+class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
+  final SettingsRepository _settingsRepository;
+
+  SettingsBloc({
+    required SettingsRepository settingsRepository,
+  })  : _settingsRepository = settingsRepository,
+        super(SettingsState.initial()) {
+    on<LoadSettings>(_onLoadSettings);
+    on<ToggleDarkMode>(_onToggleDarkMode);
+    on<SetDarkMode>(_onSetDarkMode);
+  }
+
+  Future<void> _onLoadSettings(
+    LoadSettings event,
+    Emitter<SettingsState> emit,
+  ) async {
+    emit(state.copyWith(isLoading: true));
+
+    final isDarkMode = await _settingsRepository.getDarkMode();
+
+    emit(state.copyWith(
+      isDarkMode: isDarkMode,
+      isLoading: false,
+    ));
+  }
+
+  Future<void> _onToggleDarkMode(
+    ToggleDarkMode event,
+    Emitter<SettingsState> emit,
+  ) async {
+    final newDarkMode = !state.isDarkMode;
+
+    emit(state.copyWith(isDarkMode: newDarkMode));
+
+    await _settingsRepository.setDarkMode(newDarkMode);
+  }
+
+  Future<void> _onSetDarkMode(
+    SetDarkMode event,
+    Emitter<SettingsState> emit,
+  ) async {
+    emit(state.copyWith(isDarkMode: event.enabled));
+
+    await _settingsRepository.setDarkMode(event.enabled);
+  }
+}

--- a/lib/presentation/blocs/settings/settings_bloc.dart
+++ b/lib/presentation/blocs/settings/settings_bloc.dart
@@ -7,10 +7,9 @@ import 'settings_state.dart';
 class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   final SettingsRepository _settingsRepository;
 
-  SettingsBloc({
-    required SettingsRepository settingsRepository,
-  })  : _settingsRepository = settingsRepository,
-        super(SettingsState.initial()) {
+  SettingsBloc({required SettingsRepository settingsRepository})
+    : _settingsRepository = settingsRepository,
+      super(SettingsState.initial()) {
     on<LoadSettings>(_onLoadSettings);
     on<ToggleDarkMode>(_onToggleDarkMode);
     on<SetDarkMode>(_onSetDarkMode);
@@ -24,10 +23,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
 
     final isDarkMode = await _settingsRepository.getDarkMode();
 
-    emit(state.copyWith(
-      isDarkMode: isDarkMode,
-      isLoading: false,
-    ));
+    emit(state.copyWith(isDarkMode: isDarkMode, isLoading: false));
   }
 
   Future<void> _onToggleDarkMode(

--- a/lib/presentation/blocs/settings/settings_event.dart
+++ b/lib/presentation/blocs/settings/settings_event.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SettingsEvent extends Equatable {
+  const SettingsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadSettings extends SettingsEvent {
+  const LoadSettings();
+}
+
+class ToggleDarkMode extends SettingsEvent {
+  const ToggleDarkMode();
+}
+
+class SetDarkMode extends SettingsEvent {
+  final bool enabled;
+
+  const SetDarkMode(this.enabled);
+
+  @override
+  List<Object?> get props => [enabled];
+}

--- a/lib/presentation/blocs/settings/settings_state.dart
+++ b/lib/presentation/blocs/settings/settings_state.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+class SettingsState extends Equatable {
+  final bool isDarkMode;
+  final bool isLoading;
+
+  const SettingsState({
+    required this.isDarkMode,
+    this.isLoading = false,
+  });
+
+  factory SettingsState.initial() {
+    return const SettingsState(
+      isDarkMode: true, // Default to dark mode
+      isLoading: true,
+    );
+  }
+
+  SettingsState copyWith({
+    bool? isDarkMode,
+    bool? isLoading,
+  }) {
+    return SettingsState(
+      isDarkMode: isDarkMode ?? this.isDarkMode,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+
+  @override
+  List<Object?> get props => [isDarkMode, isLoading];
+}

--- a/lib/presentation/blocs/settings/settings_state.dart
+++ b/lib/presentation/blocs/settings/settings_state.dart
@@ -4,10 +4,7 @@ class SettingsState extends Equatable {
   final bool isDarkMode;
   final bool isLoading;
 
-  const SettingsState({
-    required this.isDarkMode,
-    this.isLoading = false,
-  });
+  const SettingsState({required this.isDarkMode, this.isLoading = false});
 
   factory SettingsState.initial() {
     return const SettingsState(
@@ -16,10 +13,7 @@ class SettingsState extends Equatable {
     );
   }
 
-  SettingsState copyWith({
-    bool? isDarkMode,
-    bool? isLoading,
-  }) {
+  SettingsState copyWith({bool? isDarkMode, bool? isLoading}) {
     return SettingsState(
       isDarkMode: isDarkMode ?? this.isDarkMode,
       isLoading: isLoading ?? this.isLoading,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -262,6 +262,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.6"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -456,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -528,6 +544,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
 
   # State management
   bloc: ^8.1.4
+  flutter_bloc: ^8.1.6
   equatable: ^2.0.7
 
   # Code generation

--- a/test/presentation/blocs/gate_simulator/gate_simulator_bloc_test.dart
+++ b/test/presentation/blocs/gate_simulator/gate_simulator_bloc_test.dart
@@ -1,0 +1,339 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:digital_logic_playground/domain/entities/gate_type.dart';
+import 'package:digital_logic_playground/domain/entities/logic_gate.dart';
+import 'package:digital_logic_playground/domain/repositories/settings_repository.dart';
+import 'package:digital_logic_playground/domain/usecases/calculate_gate_output.dart';
+import 'package:digital_logic_playground/presentation/blocs/gate_simulator/gate_simulator_bloc.dart';
+import 'package:digital_logic_playground/presentation/blocs/gate_simulator/gate_simulator_event.dart';
+import 'package:digital_logic_playground/presentation/blocs/gate_simulator/gate_simulator_state.dart';
+
+class MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late GateSimulatorBloc bloc;
+  late CalculateGateOutput calculateGateOutput;
+  late MockSettingsRepository mockSettingsRepository;
+
+  setUpAll(() {
+    registerFallbackValue(GateType.and);
+  });
+
+  setUp(() {
+    calculateGateOutput = CalculateGateOutput();
+    mockSettingsRepository = MockSettingsRepository();
+    bloc = GateSimulatorBloc(
+      calculateGateOutput: calculateGateOutput,
+      settingsRepository: mockSettingsRepository,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('GateSimulatorBloc', () {
+    test('initial state is GateSimulatorState.initial()', () {
+      expect(bloc.state, equals(GateSimulatorState.initial()));
+    });
+
+    group('SelectGateType', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'emits state with AND gate and saves to repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.saveLastGateType(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SelectGateType(GateType.and)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: false,
+            inputB: false,
+            output: false,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockSettingsRepository.saveLastGateType(GateType.and),
+          ).called(1);
+        },
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'emits state with OR gate and calculates correct output',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.saveLastGateType(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.and,
+          currentGate: LogicGate.fromType(GateType.and),
+          inputA: true,
+          inputB: false,
+          output: false,
+        ),
+        act: (bloc) => bloc.add(const SelectGateType(GateType.or)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.or,
+            currentGate: LogicGate.fromType(GateType.or),
+            inputA: true,
+            inputB: false,
+            output: true, // OR gate with A=true, B=false outputs true
+          ),
+        ],
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'emits state with NOT gate',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.saveLastGateType(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SelectGateType(GateType.not)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.not,
+            currentGate: LogicGate.fromType(GateType.not),
+            inputA: false,
+            inputB: false,
+            output: true, // NOT gate with A=false outputs true
+          ),
+        ],
+      );
+    });
+
+    group('ToggleInputA', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'toggles input A from false to true and recalculates output',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const ToggleInputA()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: true,
+            inputB: false,
+            output: false, // AND gate with A=true, B=false outputs false
+          ),
+        ],
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'toggles input A from true to false',
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.and,
+          currentGate: LogicGate.fromType(GateType.and),
+          inputA: true,
+          inputB: true,
+          output: true,
+        ),
+        act: (bloc) => bloc.add(const ToggleInputA()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: false,
+            inputB: true,
+            output: false, // AND gate with A=false, B=true outputs false
+          ),
+        ],
+      );
+    });
+
+    group('ToggleInputB', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'toggles input B from false to true and recalculates output',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const ToggleInputB()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: false,
+            inputB: true,
+            output: false, // AND gate with A=false, B=true outputs false
+          ),
+        ],
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'toggles input B from true to false',
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.or,
+          currentGate: LogicGate.fromType(GateType.or),
+          inputA: false,
+          inputB: true,
+          output: true,
+        ),
+        act: (bloc) => bloc.add(const ToggleInputB()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.or,
+            currentGate: LogicGate.fromType(GateType.or),
+            inputA: false,
+            inputB: false,
+            output: false, // OR gate with A=false, B=false outputs false
+          ),
+        ],
+      );
+    });
+
+    group('SetInputA', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'sets input A to true and recalculates output',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetInputA(true)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: true,
+            inputB: false,
+            output: false,
+          ),
+        ],
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'sets input A to false',
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.not,
+          currentGate: LogicGate.fromType(GateType.not),
+          inputA: true,
+          inputB: false,
+          output: false,
+        ),
+        act: (bloc) => bloc.add(const SetInputA(false)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.not,
+            currentGate: LogicGate.fromType(GateType.not),
+            inputA: false,
+            inputB: false,
+            output: true, // NOT gate with A=false outputs true
+          ),
+        ],
+      );
+    });
+
+    group('SetInputB', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'sets input B to true and recalculates output',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetInputB(true)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.and,
+            currentGate: LogicGate.fromType(GateType.and),
+            inputA: false,
+            inputB: true,
+            output: false,
+          ),
+        ],
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'sets input B to false with XOR gate',
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.xor,
+          currentGate: LogicGate.fromType(GateType.xor),
+          inputA: true,
+          inputB: true,
+          output: false,
+        ),
+        act: (bloc) => bloc.add(const SetInputB(false)),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.xor,
+            currentGate: LogicGate.fromType(GateType.xor),
+            inputA: true,
+            inputB: false,
+            output: true, // XOR gate with A=true, B=false outputs true
+          ),
+        ],
+      );
+    });
+
+    group('LoadLastGateType', () {
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'loads last gate type from repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.getLastGateType(),
+          ).thenAnswer((_) async => GateType.or);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LoadLastGateType()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.or,
+            currentGate: LogicGate.fromType(GateType.or),
+            inputA: false,
+            inputB: false,
+            output: false,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.getLastGateType()).called(1);
+        },
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'does not change state when repository returns null',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.getLastGateType(),
+          ).thenAnswer((_) async => null);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LoadLastGateType()),
+        expect: () => [],
+        verify: (_) {
+          verify(() => mockSettingsRepository.getLastGateType()).called(1);
+        },
+      );
+
+      blocTest<GateSimulatorBloc, GateSimulatorState>(
+        'loads NAND gate and preserves current inputs',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.getLastGateType(),
+          ).thenAnswer((_) async => GateType.nand);
+        },
+        build: () => bloc,
+        seed: () => GateSimulatorState(
+          currentGateType: GateType.and,
+          currentGate: LogicGate.fromType(GateType.and),
+          inputA: true,
+          inputB: true,
+          output: true,
+        ),
+        act: (bloc) => bloc.add(const LoadLastGateType()),
+        expect: () => [
+          GateSimulatorState(
+            currentGateType: GateType.nand,
+            currentGate: LogicGate.fromType(GateType.nand),
+            inputA: true,
+            inputB: true,
+            output: false, // NAND gate with A=true, B=true outputs false
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/presentation/blocs/settings/settings_bloc_test.dart
+++ b/test/presentation/blocs/settings/settings_bloc_test.dart
@@ -96,9 +96,7 @@ void main() {
         build: () => bloc,
         seed: () => const SettingsState(isDarkMode: false, isLoading: false),
         act: (bloc) => bloc.add(const ToggleDarkMode()),
-        expect: () => [
-          const SettingsState(isDarkMode: true, isLoading: false),
-        ],
+        expect: () => [const SettingsState(isDarkMode: true, isLoading: false)],
         verify: (_) {
           verify(() => mockSettingsRepository.setDarkMode(true)).called(1);
         },
@@ -116,9 +114,7 @@ void main() {
         build: () => bloc,
         seed: () => const SettingsState(isDarkMode: false, isLoading: false),
         act: (bloc) => bloc.add(const SetDarkMode(true)),
-        expect: () => [
-          const SettingsState(isDarkMode: true, isLoading: false),
-        ],
+        expect: () => [const SettingsState(isDarkMode: true, isLoading: false)],
         verify: (_) {
           verify(() => mockSettingsRepository.setDarkMode(true)).called(1);
         },

--- a/test/presentation/blocs/settings/settings_bloc_test.dart
+++ b/test/presentation/blocs/settings/settings_bloc_test.dart
@@ -1,0 +1,146 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:digital_logic_playground/domain/repositories/settings_repository.dart';
+import 'package:digital_logic_playground/presentation/blocs/settings/settings_bloc.dart';
+import 'package:digital_logic_playground/presentation/blocs/settings/settings_event.dart';
+import 'package:digital_logic_playground/presentation/blocs/settings/settings_state.dart';
+
+class MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late SettingsBloc bloc;
+  late MockSettingsRepository mockSettingsRepository;
+
+  setUp(() {
+    mockSettingsRepository = MockSettingsRepository();
+    bloc = SettingsBloc(settingsRepository: mockSettingsRepository);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('SettingsBloc', () {
+    test('initial state is SettingsState.initial()', () {
+      expect(bloc.state, equals(SettingsState.initial()));
+      expect(bloc.state.isDarkMode, true);
+      expect(bloc.state.isLoading, true);
+    });
+
+    group('LoadSettings', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'emits loading then loaded state with dark mode enabled',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.getDarkMode(),
+          ).thenAnswer((_) async => true);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LoadSettings()),
+        expect: () => [
+          const SettingsState(isDarkMode: true, isLoading: true),
+          const SettingsState(isDarkMode: true, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.getDarkMode()).called(1);
+        },
+      );
+
+      blocTest<SettingsBloc, SettingsState>(
+        'emits loading then loaded state with dark mode disabled',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.getDarkMode(),
+          ).thenAnswer((_) async => false);
+        },
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LoadSettings()),
+        expect: () => [
+          const SettingsState(isDarkMode: true, isLoading: true),
+          const SettingsState(isDarkMode: false, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.getDarkMode()).called(1);
+        },
+      );
+    });
+
+    group('ToggleDarkMode', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'toggles dark mode from true to false and saves to repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.setDarkMode(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        seed: () => const SettingsState(isDarkMode: true, isLoading: false),
+        act: (bloc) => bloc.add(const ToggleDarkMode()),
+        expect: () => [
+          const SettingsState(isDarkMode: false, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.setDarkMode(false)).called(1);
+        },
+      );
+
+      blocTest<SettingsBloc, SettingsState>(
+        'toggles dark mode from false to true and saves to repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.setDarkMode(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        seed: () => const SettingsState(isDarkMode: false, isLoading: false),
+        act: (bloc) => bloc.add(const ToggleDarkMode()),
+        expect: () => [
+          const SettingsState(isDarkMode: true, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.setDarkMode(true)).called(1);
+        },
+      );
+    });
+
+    group('SetDarkMode', () {
+      blocTest<SettingsBloc, SettingsState>(
+        'sets dark mode to true and saves to repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.setDarkMode(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        seed: () => const SettingsState(isDarkMode: false, isLoading: false),
+        act: (bloc) => bloc.add(const SetDarkMode(true)),
+        expect: () => [
+          const SettingsState(isDarkMode: true, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.setDarkMode(true)).called(1);
+        },
+      );
+
+      blocTest<SettingsBloc, SettingsState>(
+        'sets dark mode to false and saves to repository',
+        setUp: () {
+          when(
+            () => mockSettingsRepository.setDarkMode(any()),
+          ).thenAnswer((_) async => {});
+        },
+        build: () => bloc,
+        seed: () => const SettingsState(isDarkMode: true, isLoading: false),
+        act: (bloc) => bloc.add(const SetDarkMode(false)),
+        expect: () => [
+          const SettingsState(isDarkMode: false, isLoading: false),
+        ],
+        verify: (_) {
+          verify(() => mockSettingsRepository.setDarkMode(false)).called(1);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
   Added GateSimulatorBloc:
   - Event handlers for gate selection, input toggling, and input setting
   - Automatically calculates output using CalculateGateOutput use case
   - Persists last selected gate type via SettingsRepository
   - Loads last selected gate on initialization

   Added SettingsBloc:
   - Manages dark mode preference
   - Loads and saves settings via SettingsRepository
   - Provides loading state for initial settings fetch

   Enhanced LogicGate entity:
   - Added fromType factory method for convenient gate instantiation

   Dependency Injection:
   - Registered BLoCs as factories in get_it
   - BLoCs properly depend on repositories and use cases

   Dependencies:
   - Added flutter_bloc ^8.1.6 for state management

   Testing:
   - Comprehensive unit tests for GateSimulatorBloc (15 tests)
   - Comprehensive unit tests for SettingsBloc (7 tests)
   - All 88 tests passing with 100% coverage for presentation layer
   - Used mocktail with proper fallback value registration